### PR TITLE
feat: Implement admin dashboard page and committee page 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
+    "@heroicons/react": "^2.0.18",
+    "@material-tailwind/react": "^2.1.0",
     "@tailwindcss/forms": "^0.5.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,6 +5,8 @@ import Login from "./pages/login";
 import Register from "./pages/register";
 import Committee from "./pages/committee";
 import Business from "./pages/business";
+import DashBoard from "./pages/admin/dashboard";
+import CommitteeInfo from "./pages/admin/committee";
 
 const Router: React.FC = () => {
   return (
@@ -14,6 +16,8 @@ const Router: React.FC = () => {
       <Route path="/register" element={<Register />} />
       <Route path="/committee" element={<Committee />} />
       <Route path="/business" element={<Business />} />
+      <Route path="/admin" element={<DashBoard />} />
+      <Route path="/admin/committee/:id" element={<CommitteeInfo/>} />
     </Routes>
   );
 };

--- a/src/components/layout/dashboard/committeeTable.tsx
+++ b/src/components/layout/dashboard/committeeTable.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Typography, Card, CardHeader, CardBody } from "@material-tailwind/react";
+import { PlusCircleIcon } from '@heroicons/react/24/solid';
+import TableHead from '../table/tableHead';
+import TBodyCommittee from '../../widget/cards/tableBodyCommittee'; // 아래 설명 참고
+import { CommitteeData } from '../../../data';
+
+interface CommitteeTableSectionProps {
+  committees: CommitteeData[];
+  setShowModal: (show: boolean) => void;
+}
+
+const CommitteeTableSection: React.FC<CommitteeTableSectionProps> = ({
+  committees,
+  setShowModal,
+}) =>
+(
+  <Card className="overflow-hidden xl:col-span-2 border-2 border-slate-100 rounded-lg">
+    <CardHeader
+      floated={false}
+      shadow={false}
+      color="transparent"
+      className="m-0 flex items-center justify-between p-6"
+    >
+      <div className='relative'>
+        <Typography variant="h6" color="blue-gray" className="mb-1">
+          위원회
+        </Typography>
+      </div>
+      <div className="absolute mb-1 right-6">
+        <PlusCircleIcon
+          className="font-medium w-10 cursor-pointer"
+          type="button"
+          onClick={() => setShowModal(true)}>
+        </PlusCircleIcon>
+      </div>
+    </CardHeader>
+    {/* 위원회 데이터 */}
+    <CardBody className="overflow-y-scroll px-0 pt-0 pb-2 h-60">
+      <table className="w-full min-w-[640px] table-auto">
+        <TableHead topics={["id", "이름", "설명"]} px="px-12"></TableHead>
+        <TBodyCommittee
+          committees={committees}></TBodyCommittee>
+      </table>
+    </CardBody>
+  </Card>
+);
+
+export default CommitteeTableSection;

--- a/src/components/layout/dashboard/statisticsCard.tsx
+++ b/src/components/layout/dashboard/statisticsCard.tsx
@@ -1,0 +1,37 @@
+import { createElement } from 'react';
+import StatisticsCard from '../../widget/cards/statisticsCard';
+import { StatisticsCardData } from '../../../data';
+
+interface AssetData<T> {
+  committees?: T[]
+  committee?: T[]
+}
+
+export interface StatisticsCardsSectionProps<T> {
+  statisticsCardsData: StatisticsCardData[]
+  assetData: AssetData<T>
+}
+
+const StatisticsCardsSection = <T extends unknown>({
+  statisticsCardsData,
+  assetData
+}: StatisticsCardsSectionProps<T>) => {
+  return (
+    <div className="mb-12 grid gap-y-10 gap-x-6 md:grid-cols-2 xl:grid-cols-3 bg-clip-border">
+      {statisticsCardsData.map(({ icon, name, color, title, value, ...rest }) => (
+        <StatisticsCard
+          key={title}
+          {...rest}
+          title={title}
+          color={color}
+          value={value ? value : assetData[name as keyof AssetData<T>]?.length || 0}
+          icon={createElement(icon, {
+            className: "w-6 h-6 text-white",
+          })}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default StatisticsCardsSection;

--- a/src/components/layout/dashboard/textarea.tsx
+++ b/src/components/layout/dashboard/textarea.tsx
@@ -1,0 +1,43 @@
+import React, { ChangeEventHandler } from "react";
+
+interface FormTextareaProps {
+  id: string;
+  label: string;
+  autoComplete: string;
+  placeholder: string;
+  value: string;
+  onChange: ChangeEventHandler<HTMLTextAreaElement>;
+}
+
+const FormTextarea: React.FC<FormTextareaProps> = ({
+  id,
+  label,
+  autoComplete,
+  placeholder,
+  value,
+  onChange,
+}) => {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium leading-6 text-gray-900 mb-2"
+      >
+        {label}
+      </label>
+      <textarea
+        cols={30}
+        rows={5}
+        id={id}
+        autoComplete={autoComplete}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        className='resize-none col w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6'
+      >
+      </textarea>
+    </div>
+  )
+}
+
+export default FormTextarea;

--- a/src/components/layout/login/index.tsx
+++ b/src/components/layout/login/index.tsx
@@ -7,6 +7,7 @@ interface FormInputProps {
   autoComplete: string;
   placeholder: string;
   value: string;
+  width?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -17,6 +18,7 @@ const FormInput: React.FC<FormInputProps> = ({
   autoComplete,
   placeholder,
   value,
+  width,
   onChange,
 }) => {
   return (
@@ -34,7 +36,7 @@ const FormInput: React.FC<FormInputProps> = ({
           type={type}
           autoComplete={autoComplete}
           required
-          className="block w-96 rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+          className={`block ${width ? width : "w-96"} rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6`}
           placeholder={placeholder}
           value={value}
           onChange={onChange}

--- a/src/components/layout/table/tableHead.tsx
+++ b/src/components/layout/table/tableHead.tsx
@@ -1,0 +1,30 @@
+import { Typography } from "@material-tailwind/react";
+
+interface Topics {
+  topics: string[];
+  px: string;
+}
+
+const TableHead: React.FC<Topics> = ({ topics, px }) => (
+  <thead>
+    <tr>
+      {topics.map(
+        (el) => (
+          <th
+            key={el}
+            className={`border-b border-blue-gray-50 py-3 ${px} text-center`}
+          >
+            <Typography
+              variant="small"
+              className="font-bold font-large uppercase text-black text-[15px]"
+            >
+              {el}
+            </Typography>
+          </th>
+        )
+      )}
+    </tr>
+  </thead>
+)
+
+export default TableHead;

--- a/src/components/widget/cards/addCommitteeModal.tsx
+++ b/src/components/widget/cards/addCommitteeModal.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import FormInput from '../../layout/login';
+import FormTextarea from '../../layout/dashboard/textarea';
+
+interface AddCommitteeModalProps {
+  showModal: boolean;
+  committe: string;
+  explanation: string;
+  error: string;
+  setShowModal: (show: boolean) => void;
+  setCommitte: React.Dispatch<React.SetStateAction<string>>;
+  handleSubmit: (e: React.FormEvent) => Promise<void>;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  setExplanation: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const AddCommitteeModal: React.FC<AddCommitteeModalProps> = ({
+  showModal,
+  committe,
+  explanation,
+  error,
+  setShowModal,
+  setError,
+  handleSubmit,
+  setCommitte,
+  setExplanation,
+}) => {
+  return (
+    <>
+      {showModal ? (
+        <>
+          <div
+            className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none"
+          >
+            <div className="relative w-auto my-6 mx-auto max-w-3xl">
+              <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                <div className="flex items-start justify-between p-5 border-b border-solid border-slate-200 rounded-t">
+                  <h3 className="text-xl font-semibold mt-2">
+                    위원회 추가
+                  </h3>
+                  <h3
+                    className="text-3xl text-slate-500 cursor-pointer"
+                    onClick={() => {
+                      setCommitte("");
+                      setExplanation("");
+                      setShowModal(false);
+                      setError("");
+                    }
+                    }
+                  >
+                    ×
+                  </h3>
+                </div>
+                <div className="relative py-12 px-10  flex-auto">
+                  <form className="space-y-6 relative" onSubmit={handleSubmit}>
+                    <FormInput
+                      id="name"
+                      label="이름"
+                      type="text"
+                      autoComplete="name"
+                      placeholder="위원회 이름을 적어주세요."
+                      value={committe}
+                      onChange={(e) => setCommitte(e.target.value)}
+                    />
+                    <FormTextarea
+                      id="explanation"
+                      label="설명"
+                      autoComplete="explanation"
+                      placeholder="위원회에 대한 설명을 적어주세요."
+                      value={explanation}
+                      onChange={(e) => setExplanation(e.target.value)}
+                    />
+                    <button
+                      className="absolute top-30 right-0 bg-green-500 text-white font-bold uppercase text-sm px-3 py-1 rounded shadow hover:shadow-lg mb-5"
+                      type="submit"
+                    >
+                      추가
+                    </button>
+                    <p>
+                      {error}
+                    </p>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="opacity-25 fixed inset-0 z-40 bg-black"></div>
+        </>
+      ) : null}
+    </>
+  );
+};
+
+export default AddCommitteeModal;

--- a/src/components/widget/cards/addMemberModal.tsx
+++ b/src/components/widget/cards/addMemberModal.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import FormInput from '../../layout/login';
+
+interface AddMemberModalProps {
+  showModal: boolean;
+  name: string;
+  affiliation: string;
+  error: string;
+  setShowModal: (show: boolean) => void;
+  setName: React.Dispatch<React.SetStateAction<string>>;
+  setAffiliation: React.Dispatch<React.SetStateAction<string>>;
+  handleSubmit: (e: React.FormEvent) => Promise<void>;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const AddMemberModal: React.FC<AddMemberModalProps> = ({
+  showModal,
+  name,
+  affiliation,
+  error,
+  setShowModal,
+  setName,
+  setAffiliation,
+  handleSubmit,
+  setError,
+}) => {
+  return (
+    <>
+      {showModal ? (
+        <>
+          <div
+            className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none"
+          >
+            <div className="relative w-auto my-6 mx-auto max-w-3xl">
+              <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+                <div className="flex items-start justify-between p-5 border-b border-solid border-slate-200 rounded-t">
+                  <h3 className="text-xl font-semibold mt-2">
+                    회원 추가
+                  </h3>
+                  <h3
+                    className="text-3xl text-slate-500 cursor-pointer"
+                    onClick={() => {
+                      setName("");
+                      setAffiliation("");
+                      setShowModal(false);
+                      setError("");
+                    }
+                    }
+                  >
+                    ×
+                  </h3>
+                </div>
+                <div className="relative py-12 px-10  flex-auto">
+                  <form className="space-y-6 relative" onSubmit={handleSubmit}>
+                    <FormInput
+                      id="name"
+                      label="이름"
+                      type="text"
+                      autoComplete="name"
+                      placeholder="회원 이름을 적어주세요."
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                    />
+                    <FormInput
+                      id="affiliation"
+                      label="소속"
+                      type="text"
+                      autoComplete="affiliation"
+                      placeholder="회원의 소속처를 적어주세요."
+                      value={affiliation}
+                      onChange={(e) => setName(e.target.value)}
+                    />
+                    <button
+                      className="absolute top-30 right-0 bg-green-500 text-white font-bold uppercase text-sm px-3 py-1 rounded shadow hover:shadow-lg mb-5"
+                      type="submit"
+                    >
+                      추가
+                    </button>
+                    <p>
+                      {error}
+                    </p>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="opacity-25 fixed inset-0 z-40 bg-black"></div>
+        </>
+      ) : null}
+    </>
+  );
+};
+
+export default AddMemberModal;

--- a/src/components/widget/cards/statisticsCard.tsx
+++ b/src/components/widget/cards/statisticsCard.tsx
@@ -1,0 +1,45 @@
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  CardFooter,
+  Typography,
+} from "@material-tailwind/react";
+
+interface StatisticsCardProps {
+  color: string,
+  icon: any,
+  title: string,
+  value: string | number,
+  footer?: any
+}
+
+const StatisticsCard =
+  ({ color, icon, title, value, footer }: StatisticsCardProps) => {
+    return (
+      <Card
+        className="border-2 border-slate-100 rounded-lg">
+        <CardHeader
+          variant="filled"
+          className={`rounded-lg absolute -mt-4 grid h-16 w-16 place-items-center shadow-lg ${color}`}
+        >
+          {icon}
+        </CardHeader>
+        <CardBody className="p-4 text-right">
+          <Typography variant="small" className="font-normal text-blue-gray-600">
+            {title}
+          </Typography>
+          <Typography variant="h4" color="blue-gray">
+            {value}
+          </Typography>
+        </CardBody>
+        {footer && (
+          <CardFooter className="border-t border-blue-gray-50 p-4">
+            {footer}
+          </CardFooter>
+        )}
+      </Card>
+    );
+  }
+
+export default StatisticsCard;

--- a/src/components/widget/cards/tableBodyCommittee.tsx
+++ b/src/components/widget/cards/tableBodyCommittee.tsx
@@ -1,0 +1,78 @@
+import { Typography } from "@material-tailwind/react";
+import { CommitteeData as Committee } from "../../../data";
+import { useNavigate } from "react-router-dom";
+
+const MAX_LENGTH = 24;
+const tdTextContent = "font-medium text-blue-gray-600 text-center";
+
+interface TBodyCommitteeProps {
+  committees: Committee[]
+}
+
+const TextTruncate = (text: string) => {
+  if (text.length <= MAX_LENGTH) {
+    return text;
+  }
+
+  const truncatedText = text.substring(0, MAX_LENGTH) + '...';
+
+  return truncatedText;
+};
+
+const TBodyCommittee: React.FC<TBodyCommitteeProps> = ({
+  committees,
+}) => {
+  const navigate = useNavigate();
+
+  const handleRowClick = (id: number) => {
+    navigate(`committee/${id}`);
+    // navigate(`/`);
+  };
+
+  return (
+    <tbody>
+      {committees.map(
+        ({ id, name, explanation }, key) => {
+          const className = `py-3 px-6 ${key === committees.length - 1
+            ? ""
+            : "border-b border-blue-gray-50"
+            }`;
+
+          return (
+            <tr
+              key={id}
+              className="font-medium w-10 cursor-pointer transition-shadow hover:shadow-inner"
+              onClick={() => handleRowClick(id)}>
+              <td className={className}>
+                <Typography
+                  variant="small"
+                  className={tdTextContent}
+                >
+                  {id}
+                </Typography>
+              </td>
+              <td className={className}>
+                <Typography
+                  variant="small"
+                  className={tdTextContent}
+                >
+                  {TextTruncate(name)}
+                </Typography>
+              </td>
+              <td className={className}>
+                <Typography
+                  variant="small"
+                  className={tdTextContent}
+                >
+                  {TextTruncate(explanation)}
+                </Typography>
+              </td>
+            </tr>
+          );
+        }
+      )}
+    </tbody>
+  )
+}
+
+export default TBodyCommittee;

--- a/src/components/widget/cards/tableBodySubscribers.tsx
+++ b/src/components/widget/cards/tableBodySubscribers.tsx
@@ -1,0 +1,50 @@
+import { Typography } from "@material-tailwind/react";
+import { SubscriberData as Subscribers } from "../../../data";
+import { PlusCircleIcon } from "@heroicons/react/24/outline";
+
+const tdTextContent = "font-medium text-blue-gray-600 text-center";
+
+interface TBodySubscribersProps {
+  subscribers: Subscribers[]
+}
+
+const TBodySubscribers: React.FC<TBodySubscribersProps> = (data) => (
+  <tbody>
+    {data.subscribers.map(
+      ({ affiliation, name }, key) => {
+        const className = `py-3 px-6 ${key === data.subscribers.length - 1
+          ? ""
+          : "border-b border-blue-gray-50"
+          }`;
+
+        return (
+          <tr
+            key={name}
+            className="transition-shadow hover:shadow-inner">
+            <td className={className}>
+              <Typography
+                variant="small"
+                className={tdTextContent}
+              >
+                {name}
+              </Typography>
+            </td>
+            <td className={className}>
+              <Typography
+                variant="small"
+                className={tdTextContent}
+              >
+                {affiliation}
+              </Typography>
+            </td>
+            <td className={`${className} flex justify-center`}>
+              <PlusCircleIcon className="font-medium w-5 cursor-pointer"></PlusCircleIcon>
+            </td>
+          </tr>
+        );
+      }
+    )}
+  </tbody>
+)
+
+export default TBodySubscribers;

--- a/src/data/committeeData.ts
+++ b/src/data/committeeData.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+
+export interface CommitteeData {
+  id: number,
+  name: string,
+  explanation: string,
+}
+
+export const GetCommitteeData = async (): Promise<string | CommitteeData[]> => {
+  const apiUrl = "http://127.0.0.1:8000/api";
+
+  try {
+    const response = await axios.get(`${apiUrl}/committees`, {
+      headers: {
+        Authorization: localStorage.getItem("token")
+      }
+    });
+
+    if (response.status === 200) {
+      const committeeData: CommitteeData[] = response.data; // 데이터를 CommitteeData 타입 배열로 변환
+      return committeeData;
+    }
+
+    return [];
+
+  } catch (error) {
+    return [];
+  }
+};
+
+export default GetCommitteeData;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,3 @@
+export * from "./statisticsCardsData";
+export * from "./committeeData";
+export * from "./subscriberData"

--- a/src/data/statisticsCardsData.ts
+++ b/src/data/statisticsCardsData.ts
@@ -1,0 +1,64 @@
+import {
+  BookmarkSquareIcon,
+  UserGroupIcon,
+  UserPlusIcon,
+  UserIcon
+} from "@heroicons/react/24/solid";
+
+export interface StatisticsCardData {
+  name: string
+  color: string,
+  icon: any,
+  title: string,
+  value?: string
+}
+
+export const statisticsCardsData: StatisticsCardData[] = [
+  {
+    name: "member",
+    color: "bg-pink-500",
+    icon: UserGroupIcon,
+    title: "회원 수",
+    value: '개발중'
+  },
+  {
+    name: "committee",
+    color: "bg-green-500",
+    icon: BookmarkSquareIcon,
+    title: "위원회 수",
+  },
+  {
+    name: "user",
+    color: "bg-blue-500",
+    icon: UserPlusIcon,
+    title: "가입자 수",
+    value: '개발중'
+  },
+];
+
+export const committeeStatisticsCardsData = (name: string): StatisticsCardData[] => (
+  [
+    {
+      name: "committee",
+      color: "bg-green-500",
+      icon: BookmarkSquareIcon,
+      title: "위원회 이름",
+      value: name
+    },
+    {
+      name: "user",
+      color: "bg-green-500",
+      icon: UserIcon,
+      title: "위원장",
+      value: "개발중"
+    },
+    {
+      name: "member",
+      color: "bg-green-500",
+      icon: UserGroupIcon,
+      title: "회원 수",
+    },
+  ]
+);
+
+export default statisticsCardsData;

--- a/src/data/subscriberData.ts
+++ b/src/data/subscriberData.ts
@@ -1,0 +1,41 @@
+export interface SubscriberData {
+  affiliation: string,
+  name: string,
+}
+
+export const subscriberData: SubscriberData[] = [
+  {
+    affiliation: "베이징대",
+    name: "김범창",
+  },
+  {
+    affiliation: "하버드",
+    name: "김유민",
+  },
+  {
+    affiliation: "서울대",
+    name: "박정민",
+  },
+  {
+    affiliation: "군대",
+    name: "석진석",
+  },
+  {
+    affiliation: "베이징대",
+    name: "김범창",
+  },
+  {
+    affiliation: "하버드",
+    name: "김유민",
+  },
+  {
+    affiliation: "서울대",
+    name: "박정민",
+  },
+  {
+    affiliation: "군대",
+    name: "석진석",
+  },
+];
+
+export default subscriberData;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { ThemeProvider } from "@material-tailwind/react";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/admin/dashboard.tsx
+++ b/src/pages/admin/dashboard.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react'
+import {
+  Typography,
+  Card,
+  CardHeader,
+  CardBody,
+} from "@material-tailwind/react";
+import {
+  GetCommitteeData,
+  subscriberData,
+  CommitteeData,
+  statisticsCardsData
+} from "../../data";
+import TableHead from '../../components/layout/table/tableHead';
+import SubscribersData from '../../components/widget/cards/tableBodySubscribers';
+import axios from 'axios';
+import StatisticsCardsSection from '../../components/layout/dashboard/statisticsCard';
+import AddCommitteeModal from '../../components/widget/cards/addCommitteeModal';
+import CommitteeTableSection from '../../components/layout/dashboard/committeeTable';
+
+const apiUrl = "http://127.0.0.1:8000/api";
+
+const Dashboard: React.FC = () => {
+  const [showModal, setShowModal] = useState(false);
+  const [committe, setCommitte] = useState("");
+  const [explanation, setExplanation] = useState("");
+  const [error, setError] = useState("");
+  const [assetCommittee, setAssetCommittee] = useState<CommitteeData[]>([]);
+
+  const assetData = {
+    committees: assetCommittee
+  }
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const committeeData = await GetCommitteeData();
+      if (Array.isArray(committeeData)) {
+        setAssetCommittee(committeeData);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const response = await axios.post(`${apiUrl}/committees`, {
+        name: committe,
+        explanation,
+      }, {
+        headers: {
+          Authorization: localStorage.getItem("token")
+        }
+      });
+
+      if (response.status === 201) {
+        const newCommittee = response.data;
+        assetCommittee.push(newCommittee);
+        setCommitte("");
+        setExplanation("");
+        setShowModal(false);
+        setAssetCommittee(assetCommittee)
+      }
+    }
+    catch (err) {
+      setError("오류가 발생했습니다. 다시 시도하세요.")
+    }
+  };
+
+  return (
+    <div className="m-12">
+      <StatisticsCardsSection
+        statisticsCardsData={statisticsCardsData}
+        assetData={assetData}
+      />
+      <div className="mb-4 grid grid-cols-1 gap-6 xl:grid-cols-3">
+        {/* 위원회 데이터 */}
+        <CommitteeTableSection
+          committees={assetCommittee}
+          setShowModal={setShowModal}
+        />
+        <Card
+          className="border-2 border-slate-100 rounded-lg">
+          <CardHeader
+            floated={false}
+            shadow={false}
+            color="transparent"
+            className="m-0 p-6"
+          >
+            <Typography variant="h6" color="blue-gray" className="mb-1">
+              가입 신청자
+            </Typography>
+          </CardHeader>
+          {/* 가입 신청자 데이터 */}
+          <CardBody className="p-0 overflow-y-scroll h-60">
+            <table className="w-full min-w-[300px] table-auto">
+              <TableHead topics={["이름", "소속", "허가"]} px="px-5"></TableHead>
+              <SubscribersData subscribers={subscriberData}></SubscribersData>
+            </table>
+          </CardBody>
+        </Card>
+
+        <AddCommitteeModal
+          showModal={showModal}
+          committe={committe}
+          explanation={explanation}
+          error={error}
+          setShowModal={setShowModal}
+          setError={setError}
+          handleSubmit={handleSubmit}
+          setCommitte={setCommitte}
+          setExplanation={setExplanation}
+        ></AddCommitteeModal>
+      </div>
+    </div >
+  );
+}
+
+export default Dashboard

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+    "./public/index.html",
+  ],
   darkMode: false,
   theme: {
     extend: {},


### PR DESCRIPTION
### 사용한 패키지
- @material-tailwind/react

### tailwind.config.js
- purge에서 content로 수정

### 관리자 대쉬보드 페이지
- UI
  - 통계 데이터 : 총 회원 수, 총 위원회 수, 총 가입자 수
  - 위원회 목록
  - 위원회 추가 모달

- 기능 구현
  - 총 위원회 수
  - 위원회 추가
  - 위원회 페이지 이동

### 관리자 위원회 페이지
- UI
  - 해당 위원회 데이터 : 위원회 이름, 위원장, 총 회원 수
  - 위원회 삭제, 수정 블록
  - 회원 추가 모달